### PR TITLE
Typo: extra "t" in `postQBExectute` interception point

### DIFF
--- a/debugging.md
+++ b/debugging.md
@@ -4,5 +4,5 @@ There are two ways to debug Quick entities, both by hooking in to qb.
 
 qb logs all queries it runs as debug logs. Configure LogBox to output debug logs for the `qb.models.Grammars.BaseGrammar` component to view them.
 
-Additionally, qb announces a `preQBExecute` and a `postQBExectute` interception point. These interception points contain the sql and bindings being executed. You can hook in to these interception points to enable your own logging.
+Additionally, qb announces a `preQBExecute` and a `postQBExecute` interception point. These interception points contain the sql and bindings being executed. You can hook in to these interception points to enable your own logging.
 


### PR DESCRIPTION
Fairly innocuous typo.