### PR TITLE
ownerKey --> localKey

### DIFF
--- a/upgrade-guide.md
+++ b/upgrade-guide.md
@@ -262,7 +262,7 @@ Compound key support required some method and parameter name changes.  Although 
 
 * `init` arguments have changed
   * `foreignKey : String` -&gt; `foreignKeys : [String]`
-  * `ownerKey : String` -&gt; `ownerKeys : [String]`
+  * `localKey : String` -&gt; `localKeys : [String]`
 * `getQualifiedLocalKey : String` -&gt; `getQualifiedLocalKeys : [String]`
 * `getExistenceCompareKey : String` -&gt; `getExistenceCompareKeys : [String]`
 
@@ -306,7 +306,7 @@ Compound key support required some method and parameter name changes.  Although 
 
 * `init` arguments have changed
   * `foreignKey : String` -&gt; `foreignKeys : [String]`
-  * `ownerKey : String` -&gt; `ownerKeys : [String]`
+  * `localKey : String` -&gt; `localKeys : [String]`
 
 **PolymorphicHasOneOrMany.cfc**
 


### PR DESCRIPTION
Updating an older app from Quick 2 to 4 and saw that it referenced `ownerKey` instead of `localKey`. 

It may be that the change should be from `ownerKey` to `localKeys` as I don't recall when the nomenclature changed, but all the other upgrade guide references are `localKey` to `localKeys` so I figured these should be consistent. Certainly there is no mention of `ownerKey` anymore in the Quick 4 relationships.