### PR TITLE
no eager loading by default

### DIFF
--- a/guide/getting-started/retrieving-entities.md
+++ b/guide/getting-started/retrieving-entities.md
@@ -122,7 +122,7 @@ var users = getInstance( "User" ).all();
 | :--- | :--- | :--- | :--- | :--- |
 | No arguments |  | \`\` |  |  |
 
-Executes the configured query, and returns the entities in a new collection.
+Executes the configured query, eager loads any specified relations, and returns the entities in a new collection.
 
 ```javascript
 var posts = getInstance( "Post" )
@@ -137,7 +137,7 @@ var posts = getInstance( "Post" )
 | page | numeric | `false` | 1 | The page of results to return. |
 | maxRows | numeric | `false` | 25 | The number of rows to return. |
 
-Executes the configured query, and returns the entities in the configured qb pagination struct.
+Executes the configured query, eager loads any specified relations, and returns the entities in the configured qb pagination struct.
 
 ```javascript
 var posts = getInstance( "Post" )
@@ -166,7 +166,7 @@ var posts = getInstance( "Post" )
 | page | numeric | `false` | 1 | The page of results to return. |
 | maxRows | numeric | `false` | 25 | The number of rows to return. |
 
-Executes the configured query, and returns the entities in the configured qb simple pagination struct.
+Executes the configured query, eager loads any specified relations, and returns the entities in the configured qb simple pagination struct.
 
 ```javascript
 var posts = getInstance( "Post" )

--- a/guide/getting-started/retrieving-entities.md
+++ b/guide/getting-started/retrieving-entities.md
@@ -110,7 +110,7 @@ var doesUserExist = getInstance( "User" )
 | :--- | :--- | :--- | :--- | :--- |
 | No arguments |  | \`\` |  |  |
 
-Retrieves all the records for an entity. Calling `all` will ignore any non-global constraints on the query.
+Retrieves all the records for an entity in a new collection. Calling `all` will ignore any non-global constraints on the query.
 
 ```javascript
 var users = getInstance( "User" ).all();
@@ -122,7 +122,7 @@ var users = getInstance( "User" ).all();
 | :--- | :--- | :--- | :--- | :--- |
 | No arguments |  | \`\` |  |  |
 
-Executes the configured query, eager loads any relations, and returns the entities in a new collection.
+Executes the configured query, and returns the entities in a new collection.
 
 ```javascript
 var posts = getInstance( "Post" )
@@ -137,7 +137,7 @@ var posts = getInstance( "Post" )
 | page | numeric | `false` | 1 | The page of results to return. |
 | maxRows | numeric | `false` | 25 | The number of rows to return. |
 
-Executes the configured query, eager loads any relations, and returns the entities in the configured qb pagination struct.
+Executes the configured query, and returns the entities in the configured qb pagination struct.
 
 ```javascript
 var posts = getInstance( "Post" )
@@ -166,7 +166,7 @@ var posts = getInstance( "Post" )
 | page | numeric | `false` | 1 | The page of results to return. |
 | maxRows | numeric | `false` | 25 | The number of rows to return. |
 
-Executes the configured query, eager loads any relations, and returns the entities in the configured qb simple pagination struct.
+Executes the configured query, and returns the entities in the configured qb simple pagination struct.
 
 ```javascript
 var posts = getInstance( "Post" )


### PR DESCRIPTION
The description for get(), paginate() and simplepaginate() states that relations are eager loaded, but they are not. By default they are lazy loaded. The `with`  method call is what actually does eager loading. 

If its this simple, then removing the statement about eager loading is all is needed to make it clearer.