### PR TITLE
List of discriminators belongs in the parent, not the child class.

### DIFF
--- a/guide/getting-started/defining-an-entity/subclass-entities.md
+++ b/guide/getting-started/defining-an-entity/subclass-entities.md
@@ -125,23 +125,20 @@ component
 Finally, we define an array of possible discriminated entities for the parent.  This is so we don't have to scan all Quick components just to determine if there are any discriminated entities.
 
 ```javascript
-component
-    extends="Media"
-    table="book_media"
-    joinColumn="FK_media"
-    discriminatorValue="book"
+component 
+    table="media" 
+    extends="quick.models.BaseEntity" 
     accessors="true"
+    discriminatorColumn="type"
 {
-    property name="displayOrder";
-    property name="designation";
+    property name="id";
+    property name="uploadFileName";
+    property name="fileLocation";
+    property name="fileSizeBytes";
     
     variables._discriminators = [
         "BookMedia"
     ];
-
-    function approvalStatus(){
-        return belongsTo( "Book", "FK_book" );
-    }
 
 }
 ```


### PR DESCRIPTION
The code example showed the list of discriminators (child objects) in the `BookMedia` object instead of the parent `Media` object. 
Side note: The documentation for how subclassing works with discriminators is a little confusing for scenarios where subclasses may originate from the same table.  For example, some DBs aren't normalized the same, and since objects dont always relate 1:1 with the perssitence layer, developers should be able to model their objects separately from the DB table structure.  See my Github issue here for details: https://github.com/coldbox-modules/quick/issues/183