### PR TITLE
Clarify that create returns a separate entity

### DIFF
--- a/guide/getting-started/creating-new-entities.md
+++ b/guide/getting-started/creating-new-entities.md
@@ -72,6 +72,22 @@ var user = getInstance( "User" ).create( {
 
 There is no need to call `save` when using the `create` method.
 
+{% hint style="warning" %}
+`create` is a factory method. It creates, saves, and returns a **new entity instance**; it does not fill, save, or otherwise mutate the entity on which it was called. Always use the returned entity when you need the persisted record.
+{% endhint %}
+
+```javascript
+var user = getInstance( "User" ).newEntity();
+
+user = user.create( {
+    "username": "JaneDoe",
+    "email": "jane@example.com",
+    "password": "mypass1234"
+} );
+
+user.isLoaded(); // true
+```
+
 ## firstOrNew
 
 | Name                        | Type    | Required | Default | Description                                                                                                               |


### PR DESCRIPTION
Related to coldbox-modules/quick#245.

## Review

Quick `create()` is a factory method: it creates, saves, and returns a new entity instead of mutating the entity used to invoke it. The existing documentation showed the returned-value form but did not warn that ignoring the return value leaves the original entity unloaded.

This adds a warning to the canonical Creating New Entities page and demonstrates assigning the returned entity.

Supersedes coldbox-modules/quick#290.